### PR TITLE
🚸 Added "--unattended" mode to OMZ installation

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -50,7 +50,7 @@ install_git() {
 install_omz() {
     if [[ ! -d ~/.oh-my-zsh ]]; then
         echo "4. Installing oh-my-zsh"
-        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh) --unattended"
     else
         echo '"oh-my-zsh" is already installed. Skipping...'
     fi


### PR DESCRIPTION
OMZ installation was stopping the further steps since it was starting setup. Now the OMZ will be installed in "unattended" mode so that steps can continue.